### PR TITLE
Add installed_path as env variable

### DIFF
--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -224,7 +224,8 @@ class CreativeCloudVersioner(Processor):
                 'version_comparison_key': 'CFBundleShortVersionString',
             }]
         }
-
+        
+        self.env["installed_path"] = installed_path
         self.env["additional_pkginfo"] = pkginfo
         self.output("additional_pkginfo: %s" % self.env["additional_pkginfo"])
 


### PR DESCRIPTION
I'd like to use the installed_path variable in future processors. It seems to be included in the additional_pkginfo dict, but I don't believe I can pull values from that easily in future processors. Please let me know if I'm incorrect. Thanks