### PR TITLE
Wrong encoding of PackageInfo.txt

### DIFF
--- a/Adobe/CreativeCloudPackager.py
+++ b/Adobe/CreativeCloudPackager.py
@@ -390,7 +390,11 @@ class CreativeCloudPackager(Processor):
         # Save PackageInfo.txt
         packageinfo = os.path.join(expected_output_root, "PackageInfo.txt")
         if os.path.exists(packageinfo):
-            self.env["package_info_text"] = open(packageinfo, 'r').read()
+            pkginfotmp = open(packageinfo, 'r').read()
+            if isinstance(pkginfotmp, unicode):
+                self.env["package_info_text"] = pkginfotmp
+            else:
+                self.env["package_info_text"] = pkginfotmp.decode('utf8')
 
         ccp_path = os.path.join(expected_output_root, 'Build/{}.ccp'.format(self.env["package_name"]))
         if os.path.exists(ccp_path):


### PR DESCRIPTION
As in Issue #16 described, the variable elf.env["package_info_text"] gets the wrong encoding.
This change checks the encoding and decode it to UTF8 if necessary.