### PR TITLE
If we have no baseVersion, use the latest version (issue #15)

### DIFF
--- a/Adobe/CreativeCloudPackager.py
+++ b/Adobe/CreativeCloudPackager.py
@@ -180,7 +180,7 @@ class CreativeCloudPackager(Processor):
             sap = ElementTree.Element('sapCode')
             sap.text = prod['sapCode']
             ver = ElementTree.Element('version')
-            ver.text = prod['baseVersion']
+            ver.text = prod['baseVersion'] or self.env['version']
             product.append(sap)
             product.append(ver)
             products.append(product)

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -239,7 +239,17 @@ class CreativeCloudVersioner(Processor):
               app_version (str): Bundle version
               installed_path (str): The path where the installed item will be installed.
         """
-        self.env["version"] = app_version
+
+        if self.env["sapCode"] in ('LRCC', 'LTRM'):
+            # Special case for Lightroom and Lightroom Classic CC which have a 
+            # horrible string in its CFBundleShortVersionString:
+            # eg: "Adobe Lightroom CC [20180608-0705-e1ba7c8]"
+            bundle_version = re.match(r'.*\[(.*)\]', app_version).group(1)
+            bundle_version = bundle_version.replace('-', '.')
+            self.env["version"] = self.env["version"] + "." + bundle_version
+        else:
+            self.env["version"] = app_version
+        
         self.env["jss_inventory_name"] = app_bundle
         
         pkginfo = {


### PR DESCRIPTION
Latest version is already available in self.env['version']