### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Adobe/CreativeCloudBuildModifier.py
+++ b/Adobe/CreativeCloudBuildModifier.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # for debugging
+from __future__ import absolute_import
 from pprint import pprint
 import os.path
 from autopkglib import Processor, ProcessorError

--- a/Adobe/CreativeCloudBuildModifier.py
+++ b/Adobe/CreativeCloudBuildModifier.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# for debugging
 from __future__ import absolute_import
-from pprint import pprint
+
 import os.path
-from autopkglib import Processor, ProcessorError
 from xml.etree import ElementTree
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["CreativeCloudBuildModifier"]
 

--- a/Adobe/CreativeCloudFeed.py
+++ b/Adobe/CreativeCloudFeed.py
@@ -21,7 +21,6 @@ import string
 import json
 import urllib2
 from tempfile import mkdtemp
-from urllib import urlencode
 from distutils.version import LooseVersion as LV
 from xml.etree import ElementTree
 
@@ -29,6 +28,11 @@ from xml.etree import ElementTree
 from pprint import pprint
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlencode  # For Python 3
+except ImportError:
+    from urllib import urlencode  # For Python 2
 
 __all__ = ["CreativeCloudFeed"]
 

--- a/Adobe/CreativeCloudFeed.py
+++ b/Adobe/CreativeCloudFeed.py
@@ -213,7 +213,7 @@ class CreativeCloudFeed(Processor):
     def filter_product(self, data, sap_code, base_version, version='latest'):
         """Find product information from a feed dump given a single sap_code, base version and optional version."""
         product = {'version': '0.0.1'}
-        channels = string.split(self.env.get('channels'), ',')
+        channels = self.env.get('channels').split(',')
 
         #12 inputs to ccpinfo dict testing w BridgeCC
         for channel in data['channel']:
@@ -247,7 +247,7 @@ class CreativeCloudFeed(Processor):
         """Fetch extended information about a product such as: manifest,
         proxy (if available), release notes, and icon"""
         extended_info = {}
-        channels = string.split(self.env.get('channels'), ',')
+        channels = self.env.get('channels').split(',')
 
         # Fetch Icon
         if 'productIcons' in product:
@@ -355,8 +355,8 @@ class CreativeCloudFeed(Processor):
 
     def main(self):
         ccpinfo = self.env['ccpinfo']
-        channels = string.split(self.env.get('channels'), ',')
-        platforms = string.split(self.env.get('platforms'), ',')
+        channels = self.env.get('channels').split(',')
+        platforms = self.env.get('platforms').split(',')
 
         data = self.fetch(channels, platforms)
         self.validate_input()

--- a/Adobe/CreativeCloudFeed.py
+++ b/Adobe/CreativeCloudFeed.py
@@ -15,17 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import sys
-import os.path
-import string
+
 import json
+import os.path
 import urllib2
-from tempfile import mkdtemp
 from distutils.version import LooseVersion as LV
 from xml.etree import ElementTree
-
-# for debugging
-from pprint import pprint
 
 from autopkglib import Processor, ProcessorError
 

--- a/Adobe/CreativeCloudFeed.py
+++ b/Adobe/CreativeCloudFeed.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import sys
 import os.path
 import string

--- a/Adobe/CreativeCloudPackager.py
+++ b/Adobe/CreativeCloudPackager.py
@@ -20,16 +20,16 @@
 # pylint: disable=line-too-long
 
 from __future__ import absolute_import
+
 import os
 import shutil
 import subprocess
 import uuid
-import FoundationPlist
-
 from xml.etree import ElementTree
-from Foundation import CFPreferencesCopyAppValue, CFPreferencesSetAppValue
 
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
+from Foundation import CFPreferencesCopyAppValue, CFPreferencesSetAppValue
 
 __all__ = ["CreativeCloudPackager"]
 

--- a/Adobe/CreativeCloudPackager.py
+++ b/Adobe/CreativeCloudPackager.py
@@ -19,6 +19,7 @@
 # for now
 # pylint: disable=line-too-long
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -20,11 +20,11 @@
 # pylint: disable=line-too-long
 
 from __future__ import absolute_import
+
 import json
 import os
 import re
 import zipfile
-
 from xml.etree import ElementTree
 
 import FoundationPlist

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -19,6 +19,7 @@
 # for now
 # pylint: disable=line-too-long
 
+from __future__ import absolute_import
 import json
 import os
 import re


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (like handling HTTP headers), but this should catch the low-hanging fruit right now.